### PR TITLE
setheight需要在ready后使用确保生效

### DIFF
--- a/src/UEditor/wwwroot/ueditor-blazor.js
+++ b/src/UEditor/wwwroot/ueditor-blazor.js
@@ -8,7 +8,8 @@ window.UEditorBlazor = {
 
     domRef.UEditor = UE.getEditor(domRef.id, options);
     domRef.UEditor.ready(function () {
-      editor.invokeMethodAsync('HandleRendered');
+        editor.invokeMethodAsync('HandleRendered');
+        domRef.UEditor.setHeight(options.height);
     });
     domRef.UEditor.addListener('contentchange', function () {
       var content = domRef.UEditor.getContent();


### PR DESCRIPTION
在某些动态渲染的情况下初始化的height参数无效，需要在ready中设置高度